### PR TITLE
Fix exported interface include dir

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -186,7 +186,7 @@ set(libzzipmmapped_HDRS mmapped.h memdisk.h)
 
 add_library(libzzip ${libzzip_SRCS} )
 target_link_libraries(libzzip ZLIB::ZLIB )
-target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC $<INSTALL_INTERFACE:include/zzip>)
+target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if(ZZIPFSEEKO)
 add_library(libzzipfseeko ${libzzipfseeko_SRCS} )


### PR DESCRIPTION
  `include/zzip` contains a header named `stdint.h`. This headers hides the compiler's `stdint.h` when a consumer links to the exported target, resulting in errors such as (cf. x64-linux in https://dev.azure.com/vcpkg/public/_build/results?buildId=78568):
  ~~~
  error: '::int8_t' has not been declared
  ~~~
  and (cf. x64-windows in https://dev.azure.com/vcpkg/public/_build/results?buildId=78568)
  ~~~
  ...\cstdint(31): error C2039: 'int_least8_t': is not a member of '`global namespace''
  ...\cstdint(31): error C2873: 'int_least8_t': symbol cannot be used in a using-d
  ~~~
  According to the test file, the canonical pattern is `#include <zzip/zzip.h>`.
